### PR TITLE
Add JSON-RPC helper

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,3 +5,24 @@ const baseURL = import.meta.env.VITE_API_BASE ?? 'http://localhost:3000'
 export const api = axios.create({
   baseURL,
 })
+
+export interface JsonRpcResponse<TResult> {
+  result: TResult
+  error?: unknown
+}
+
+export async function callRpc<TResult = unknown>(
+  method: string,
+  params?: unknown[],
+): Promise<TResult> {
+  const { data } = await api.post<JsonRpcResponse<TResult>>('', {
+    method,
+    params,
+  })
+
+  if (data.error !== undefined && data.error !== null) {
+    throw data.error
+  }
+
+  return data.result
+}


### PR DESCRIPTION
## Summary
- add a JsonRpcResponse interface and a callRpc helper around the shared axios instance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caaf7f49b88321a541d8b03373712c