### PR TITLE
Refactor object types page to use RPC data

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,3 +5,39 @@ const baseURL = import.meta.env.VITE_API_BASE ?? 'http://localhost:3000'
 export const api = axios.create({
   baseURL,
 })
+
+type RpcPayload<TParams> = {
+  method: string
+  params?: TParams
+}
+
+type RpcError = { message?: string } | string | null | undefined
+
+type RpcEnvelope<TResult> =
+  | { result: TResult; error?: undefined }
+  | { result?: undefined; error: RpcError }
+  | TResult
+
+export async function callRpc<TResult, TParams = Record<string, unknown>>(
+  method: string,
+  params?: TParams,
+): Promise<TResult> {
+  const payload: RpcPayload<TParams> = { method, params }
+  const { data } = await api.post<RpcEnvelope<TResult>>('/rpc', payload)
+
+  if (data && typeof data === 'object') {
+    if ('error' in data && data.error) {
+      const message =
+        typeof data.error === 'string'
+          ? data.error
+          : data.error?.message ?? `RPC ${method} failed`
+      throw new Error(message)
+    }
+
+    if ('result' in data) {
+      return (data.result ?? undefined) as TResult
+    }
+  }
+
+  return data as TResult
+}

--- a/src/types/nsi-remote.ts
+++ b/src/types/nsi-remote.ts
@@ -1,0 +1,105 @@
+import type { GeometryKind } from './nsi'
+
+export interface RemoteObjectType {
+  id: string
+  name: string
+  geometryId: string | null
+  geometryName?: string | null
+}
+
+export type LoadTypesObjectsResponse = RemoteObjectType[]
+
+export interface FactorValueOption {
+  id: string
+  name: string
+  code?: string | null
+  value?: string | null
+}
+
+export type LoadFvForSelectResponse = FactorValueOption[]
+
+export interface RemoteComponentItem {
+  id: string
+  objectTypeId: string | null
+  name: string
+}
+
+export type LoadComponentsObject2Response = RemoteComponentItem[]
+
+export interface ComponentOption {
+  id: string
+  name: string
+}
+
+export type ComponentsByType = Record<string, ComponentOption[]>
+
+export interface SaveTypeObjectRequest {
+  id?: string
+  name: string
+  geometryId: string | null
+  componentIds: string[]
+}
+
+export interface SaveTypeObjectResponse {
+  id: string
+}
+
+export interface DeleteTypeObjectRequest {
+  id: string
+}
+
+const GEOMETRY_ALIASES: Record<GeometryKind, string[]> = {
+  точка: ['точка', 'point', 'pt', 'p', '1', 'g1', 'point_z', 'pointz'],
+  линия: ['линия', 'line', 'linestring', 'polyline', '2', 'g2'],
+  полигон: ['полигон', 'polygon', 'poly', 'area', 'surface', '3', 'g3'],
+}
+
+function matchGeometryAlias(value: string): GeometryKind | null {
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return null
+
+  for (const [kind, aliases] of Object.entries(GEOMETRY_ALIASES) as [
+    GeometryKind,
+    string[],
+  ][]) {
+    if (aliases.includes(normalized)) return kind
+  }
+
+  return null
+}
+
+export function normalizeGeometry(
+  raw: string | number | null | undefined,
+  options?: LoadFvForSelectResponse,
+): GeometryKind {
+  const normalizedRaw =
+    typeof raw === 'number' ? raw.toString() : (raw ?? '').toString()
+  const direct = matchGeometryAlias(normalizedRaw)
+  if (direct) return direct
+
+  const lowered = normalizedRaw.trim().toLowerCase()
+
+  if (options?.length) {
+    const matchedOption = options.find((option) =>
+      [option.id, option.name, option.value, option.code]
+        .map((candidate) => (candidate ?? '').toString().trim().toLowerCase())
+        .includes(lowered),
+    )
+
+    if (matchedOption) {
+      const candidates = [
+        matchedOption.name,
+        matchedOption.value,
+        matchedOption.code,
+        matchedOption.id,
+      ]
+
+      for (const candidate of candidates) {
+        const alias = matchGeometryAlias((candidate ?? '').toString())
+        if (alias) return alias
+      }
+    }
+  }
+
+  return 'точка'
+}


### PR DESCRIPTION
## Summary
- add a generic callRpc helper for RPC endpoints and new RPC type definitions
- refactor the object types page to load data via RPC calls, normalize geometry and manage component option caches
- switch save and delete flows to RPC methods and block ad-hoc component creation in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caaf853b2483218c316d17814267eb