### PR TITLE
Configure RPC path via environment variable

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+# RPC endpoint path for local and test backends
+VITE_RPC_PATH=/rpc

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+# RPC endpoint path for production backend
+VITE_RPC_PATH=

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,6 +4,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE: string
+  readonly VITE_RPC_PATH?: string
 }
 
 interface ImportMeta {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
 const baseURL = import.meta.env.VITE_API_BASE ?? 'http://localhost:3000'
+const rpcPath = import.meta.env.VITE_RPC_PATH ?? ''
 
 export const api = axios.create({
   baseURL,
@@ -23,7 +24,7 @@ export async function callRpc<TResult, TParams = Record<string, unknown>>(
   params?: TParams,
 ): Promise<TResult> {
   const payload: RpcPayload<TParams> = { method, params }
-  const { data } = await api.post<RpcEnvelope<TResult>>('/rpc', payload)
+  const { data } = await api.post<RpcEnvelope<TResult>>(rpcPath, payload)
 
   if (data && typeof data === 'object') {
     if ('error' in data && data.error) {


### PR DESCRIPTION
## Summary
- load the RPC endpoint path from a new `VITE_RPC_PATH` environment variable in the API helper
- extend the Vite environment typings and add environment files for production and development/test

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb93abfd648321911713f02965ee43