### PR TITLE
Add RPC-based authentication flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,16 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import S360Layout from '@/layouts/S360Layout.vue'
+
+const route = useRoute()
+const useDefaultLayout = computed(() => route.meta.layout !== 'auth')
+</script>
 
 <template>
-  <S360Layout>
+  <component :is="useDefaultLayout ? S360Layout : 'div'">
     <router-view />
-  </S360Layout>
+  </component>
 </template>
-<script setup lang="ts">
-import S360Layout from '@/layouts/S360Layout.vue'
-</script>
 
 <style scoped></style>

--- a/src/layouts/S360Layout.vue
+++ b/src/layouts/S360Layout.vue
@@ -10,6 +10,14 @@
         <router-link to="/nsi/components" class="nav-item">Компоненты</router-link>
         <!-- добавляй пункты по мере роста проекта -->
       </nav>
+
+      <div v-if="auth.isAuthenticated" class="s360-user">
+        <div class="user-details">
+          <span class="user-name">{{ userName }}</span>
+          <span v-if="userLogin" class="user-login">@{{ userLogin }}</span>
+        </div>
+        <el-button link type="primary" size="small" @click="handleLogout">Выйти</el-button>
+      </div>
     </el-aside>
 
     <!-- ПРАВАЯ КОЛОНКА -->
@@ -22,7 +30,32 @@
 </template>
 
 <script setup lang="ts">
-// без логики — это «каркас»
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+const userName = computed(() => {
+  const user = auth.user
+  return (
+    (typeof user?.name === 'string' && user.name) ||
+    (typeof user?.displayName === 'string' && user.displayName) ||
+    (typeof user?.login === 'string' && user.login) ||
+    'Пользователь'
+  )
+})
+
+const userLogin = computed(() => {
+  const login = typeof auth.user?.login === 'string' ? auth.user?.login : ''
+  return userName.value !== login ? login : ''
+})
+
+const handleLogout = async () => {
+  await auth.logout()
+  router.replace({ name: 'login' })
+}
 </script>
 
 <style scoped>
@@ -42,6 +75,8 @@
   padding: 16px 12px;
   background: #f7fbfb;
   border-right: 1px solid #e6eaea;
+  display: flex;
+  flex-direction: column;
 }
 
 /* логотип/заголовок слева */
@@ -89,5 +124,31 @@
 /* таблица пусть занимает всю доступную ширину */
 .s360-main .el-table {
   width: 100%;
+}
+
+.s360-user {
+  margin-top: auto;
+  padding: 16px 12px;
+  border-radius: 12px;
+  background: rgba(0, 109, 119, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.user-details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: #0f3e44;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-login {
+  font-size: 12px;
+  color: #476568;
 }
 </style>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,6 +5,7 @@ const rpcPath = import.meta.env.VITE_RPC_PATH ?? ''
 
 export const api = axios.create({
   baseURL,
+  withCredentials: true,
 })
 
 type RpcPayload<TParams> = {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,61 @@
+import { callRpc } from './api'
+
+export interface LoginPayload {
+  login: string
+  password: string
+}
+
+export interface AuthUser {
+  id: string | number
+  login: string
+  name?: string | null
+  displayName?: string | null
+  roles?: string[]
+  [key: string]: unknown
+}
+
+interface LoginResponseEnvelope {
+  user?: AuthUser | null
+  [key: string]: unknown
+}
+
+function extractUser(payload: AuthUser | LoginResponseEnvelope | null | undefined): AuthUser {
+  if (payload && typeof payload === 'object' && 'user' in payload) {
+    const value = (payload as LoginResponseEnvelope).user
+    if (value) return value
+  }
+
+  if (payload && typeof payload === 'object') {
+    return payload as AuthUser
+  }
+
+  throw new Error('Пустой ответ авторизации')
+}
+
+const LOGIN_METHOD = 'auth/login'
+const LOGOUT_METHOD = 'auth/logout'
+const CURRENT_USER_METHOD = 'auth/getCurrentUser'
+
+export async function login(credentials: LoginPayload): Promise<AuthUser> {
+  const response = await callRpc<AuthUser | LoginResponseEnvelope | null, LoginPayload>(
+    LOGIN_METHOD,
+    credentials,
+  )
+  return extractUser(response)
+}
+
+export async function logout(): Promise<void> {
+  await callRpc<void>(LOGOUT_METHOD)
+}
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
+  try {
+    const response = await callRpc<AuthUser | LoginResponseEnvelope | null>(CURRENT_USER_METHOD)
+    if (!response) return null
+    return extractUser(response)
+  } catch (error) {
+    // если сессии нет, сервер может вернуть ошибку — не считаем это критичным
+    console.warn('Не удалось получить информацию о текущем пользователе', error)
+    return null
+  }
+}

--- a/src/pages/auth/LoginPage.vue
+++ b/src/pages/auth/LoginPage.vue
@@ -1,0 +1,176 @@
+<template>
+  <div class="login-page">
+    <el-card class="login-card" shadow="hover">
+      <h1 class="login-title">Вход в Service360</h1>
+      <p class="login-subtitle">Введите корпоративный логин и пароль, чтобы продолжить работу в системе.</p>
+
+      <el-alert
+        v-if="errorMessage"
+        :closable="false"
+        type="error"
+        class="login-alert"
+        show-icon
+        :title="errorMessage"
+      />
+
+      <el-form
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        label-position="top"
+        @submit.prevent="onSubmit"
+      >
+        <el-form-item label="Логин" prop="login">
+          <el-input
+            v-model="form.login"
+            placeholder="Введите логин"
+            autocomplete="username"
+            autofocus
+          />
+        </el-form-item>
+        <el-form-item label="Пароль" prop="password">
+          <el-input
+            v-model="form.password"
+            type="password"
+            placeholder="Введите пароль"
+            autocomplete="current-password"
+            show-password
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button
+            class="btn-primary"
+            type="primary"
+            native-type="submit"
+            :loading="auth.loginPending"
+          >
+            Войти
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { FormInstance, FormRules } from 'element-plus'
+import { useAuthStore } from '@/stores/auth'
+
+interface LoginForm {
+  login: string
+  password: string
+}
+
+const auth = useAuthStore()
+const router = useRouter()
+const route = useRoute()
+
+const form = reactive<LoginForm>({
+  login: '',
+  password: '',
+})
+
+const formRef = ref<FormInstance>()
+const errorMessage = ref<string>('')
+
+const rules: FormRules<LoginForm> = {
+  login: [
+    { required: true, message: 'Укажите логин', trigger: 'blur' },
+    { min: 3, message: 'Минимум 3 символа', trigger: 'blur' },
+  ],
+  password: [
+    { required: true, message: 'Введите пароль', trigger: 'blur' },
+    { min: 6, message: 'Минимум 6 символов', trigger: 'blur' },
+  ],
+}
+
+watch(
+  () => auth.error,
+  (value) => {
+    errorMessage.value = value ?? ''
+  },
+  { immediate: true },
+)
+
+const onSubmit = async () => {
+  errorMessage.value = ''
+  auth.clearError()
+
+  const instance = formRef.value
+  if (!instance) return
+
+  try {
+    await instance.validate()
+  } catch (validationError) {
+    console.warn('Форма заполнена некорректно', validationError)
+    return
+  }
+
+  try {
+    await auth.login({ login: form.login, password: form.password })
+    const redirect = typeof route.query.redirect === 'string' && route.query.redirect
+      ? route.query.redirect
+      : '/'
+    await router.replace(redirect)
+  } catch (err) {
+    errorMessage.value =
+      err instanceof Error
+        ? err.message
+        : 'Не удалось выполнить вход. Повторите попытку позднее.'
+  }
+}
+</script>
+
+<style scoped>
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: radial-gradient(circle at top left, rgba(0, 109, 119, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(42, 157, 143, 0.1), transparent 55%),
+    #f5f9f9;
+}
+
+.login-card {
+  width: 100%;
+  max-width: 420px;
+  border-radius: 16px;
+  box-shadow: 0 16px 32px rgba(15, 62, 68, 0.08);
+  border: 1px solid rgba(0, 109, 119, 0.08);
+}
+
+.login-title {
+  margin: 0 0 8px;
+  font-size: 24px;
+  font-weight: 700;
+  color: #0f3e44;
+}
+
+.login-subtitle {
+  margin: 0 0 24px;
+  color: #476568;
+  font-size: 14px;
+}
+
+.login-alert {
+  margin-bottom: 18px;
+}
+
+:deep(.el-form-item__label) {
+  font-weight: 600;
+  color: #0f3e44;
+}
+
+:deep(.el-input__wrapper.is-focus) {
+  box-shadow: 0 0 0 1px #2a9d8f inset;
+}
+
+.btn-primary {
+  width: 100%;
+  font-weight: 600;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,15 +1,70 @@
 // src/router/index.ts
 import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
-// временно используем существующий компонент, чтобы увидеть, что роутер работает
-const Home = () => import('../components/HelloWorld.vue')
-const ObjectTypesPage = () => import('../pages/nsi/ObjectTypesPage.vue')
+declare module 'vue-router' {
+  interface RouteMeta {
+    requiresAuth?: boolean
+    public?: boolean
+    layout?: 'auth' | 'default'
+  }
+}
 
-export default createRouter({
+const Home = () => import('@/components/HelloWorld.vue')
+const ObjectTypesPage = () => import('@/pages/nsi/ObjectTypesPage.vue')
+const LoginPage = () => import('@/pages/auth/LoginPage.vue')
+
+const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/', name: 'home', component: Home },
-    // сюда позже добавим страницы НСИ: /nsi/object-types и т.д.
-    { path: '/nsi/object-types', name: 'object-types', component: ObjectTypesPage },
+    {
+      path: '/login',
+      name: 'login',
+      component: LoginPage,
+      meta: { public: true, layout: 'auth' },
+    },
+    {
+      path: '/',
+      name: 'home',
+      component: Home,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/nsi/object-types',
+      name: 'object-types',
+      component: ObjectTypesPage,
+      meta: { requiresAuth: true },
+    },
   ],
 })
+
+router.beforeEach(async (to, from) => {
+  const auth = useAuthStore()
+
+  if (!auth.initialized) {
+    await auth.ensureSession()
+  }
+
+  if (to.meta.public) {
+    if (to.name === 'login' && auth.isAuthenticated) {
+      const redirect =
+        typeof to.query.redirect === 'string' && to.query.redirect?.length
+          ? to.query.redirect
+          : (from.fullPath && from.fullPath !== '/login' ? from.fullPath : '/')
+      return { path: redirect }
+    }
+    return true
+  }
+
+  if (auth.isAuthenticated) {
+    return true
+  }
+
+  const redirect = to.fullPath && to.fullPath !== '/login' ? to.fullPath : undefined
+  return {
+    name: 'login',
+    query: redirect ? { redirect } : undefined,
+  }
+})
+
+export default router

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,0 +1,95 @@
+import { computed, ref } from 'vue'
+import { defineStore } from 'pinia'
+import type { AuthUser, LoginPayload } from '@/lib/auth'
+import { getCurrentUser, login as loginRpc, logout as logoutRpc } from '@/lib/auth'
+
+export const useAuthStore = defineStore('auth', () => {
+  const user = ref<AuthUser | null>(null)
+  const loginPending = ref(false)
+  const sessionLoading = ref(false)
+  const initialized = ref(false)
+  const error = ref<string | null>(null)
+
+  let sessionPromise: Promise<AuthUser | null> | null = null
+
+  const isAuthenticated = computed(() => !!user.value)
+
+  async function ensureSession(force = false): Promise<AuthUser | null> {
+    if (!force && initialized.value) return user.value
+    if (!force && sessionPromise) return sessionPromise
+
+    sessionLoading.value = true
+    sessionPromise = (async () => {
+      try {
+        const current = await getCurrentUser()
+        user.value = current
+        return user.value
+      } catch (err) {
+        user.value = null
+        throw err
+      } finally {
+        sessionLoading.value = false
+        initialized.value = true
+        sessionPromise = null
+      }
+    })()
+
+    try {
+      return await sessionPromise
+    } catch (err) {
+      console.warn('Ошибка при проверке сессии', err)
+      return null
+    }
+  }
+
+  async function login(payload: LoginPayload): Promise<AuthUser> {
+    loginPending.value = true
+    error.value = null
+    try {
+      const result = await loginRpc(payload)
+      user.value = result
+      initialized.value = true
+      return result
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'Не удалось выполнить вход. Попробуйте ещё раз.'
+      error.value = message
+      throw err instanceof Error ? err : new Error(message)
+    } finally {
+      loginPending.value = false
+    }
+  }
+
+  async function logout(): Promise<void> {
+    try {
+      await logoutRpc()
+    } catch (err) {
+      console.warn('Ошибка при выходе из системы', err)
+    } finally {
+      user.value = null
+      initialized.value = true
+    }
+  }
+
+  function setUser(next: AuthUser | null) {
+    user.value = next
+  }
+
+  function clearError() {
+    error.value = null
+  }
+
+  return {
+    user,
+    loginPending,
+    sessionLoading,
+    initialized,
+    error,
+    isAuthenticated,
+    ensureSession,
+    login,
+    logout,
+    setUser,
+    clearError,
+  }
+})


### PR DESCRIPTION
## Summary
- allow the shared axios instance to include credentials with each RPC request
- add authentication helpers and a Pinia store to manage login, logout, and current-user state
- implement a dedicated login page, protect routes with guards, and expose a logout action in the main layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbb3b17b788321abea626bb91333c0