### PR TITLE
Route API traffic through dev proxy to avoid CORS

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -3,8 +3,10 @@
 
 
 interface ImportMetaEnv {
-  readonly VITE_API_BASE: string
+  readonly VITE_API_BASE?: string
+  readonly VITE_API_DEV_PROXY_BASE?: string
   readonly VITE_RPC_PATH?: string
+  readonly VITE_AUTH_LOGIN_PATH?: string
 }
 
 interface ImportMeta {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,6 +1,64 @@
 import axios from 'axios'
 
-const baseURL = import.meta.env.VITE_API_BASE ?? 'http://localhost:3000'
+const ABSOLUTE_URL_PATTERN = /^([a-z][a-z\d+\-.]*:)?\/\//i
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function ensureLeadingSlash(value: string): string {
+  if (!value.startsWith('/')) {
+    return `/${value}`
+  }
+  return value
+}
+
+function normalizeRelativeBase(value: string | undefined | null): string {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return '/api'
+  }
+
+  const withoutTrailing = stripTrailingSlashes(trimmed)
+  if (!withoutTrailing) {
+    return '/'
+  }
+
+  return ensureLeadingSlash(withoutTrailing)
+}
+
+function resolveBaseURL(): string {
+  const rawBase = import.meta.env.VITE_API_BASE
+  const devProxyBase = normalizeRelativeBase(import.meta.env.VITE_API_DEV_PROXY_BASE)
+
+  if (!rawBase) {
+    return devProxyBase
+  }
+
+  const trimmedBase = rawBase.trim()
+  if (!trimmedBase) {
+    return devProxyBase
+  }
+
+  if (ABSOLUTE_URL_PATTERN.test(trimmedBase)) {
+    if (import.meta.env.DEV && typeof window !== 'undefined') {
+      try {
+        const target = new URL(trimmedBase)
+        if (target.origin !== window.location.origin) {
+          return devProxyBase
+        }
+      } catch {
+        return devProxyBase
+      }
+    }
+
+    return stripTrailingSlashes(trimmedBase)
+  }
+
+  return normalizeRelativeBase(trimmedBase)
+}
+
+const baseURL = resolveBaseURL()
 const rpcPath = import.meta.env.VITE_RPC_PATH ?? ''
 
 export const api = axios.create({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,12 +36,6 @@ function normalizeRelativePath(path: string | undefined | null): string {
   return withoutLeadingSlashes || 'auth/login'
 }
 
-function joinWithBase(baseURL: string | undefined, path: string): string {
-  const normalizedBase = baseURL?.replace(/\/+$/, '')
-  if (!normalizedBase) return path
-  return `${normalizedBase}/${path.replace(/^\/+/, '')}`
-}
-
 function resolveLoginPath(): string {
   const rawPath = import.meta.env.VITE_AUTH_LOGIN_PATH
 
@@ -49,10 +43,7 @@ function resolveLoginPath(): string {
     return rawPath
   }
 
-  const baseURL = api.defaults.baseURL ?? ''
-  const relativePath = normalizeRelativePath(rawPath)
-
-  return joinWithBase(baseURL, relativePath)
+  return normalizeRelativePath(rawPath)
 }
 
 const loginPath = resolveLoginPath()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,87 @@
 import { fileURLToPath, URL } from 'node:url'
 
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv, type ProxyOptions } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
-// https://vite.dev/config/
+const ABSOLUTE_URL_PATTERN = /^([a-z][a-z\d+\-.]*:)?\/\//i
 
-export default defineConfig({
-  plugins: [vue()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-server: {
-  proxy: {
-    '/api': {
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normalizeProxyBase(value: string | undefined): string {
+  if (!value) {
+    return '/api'
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return '/api'
+  }
+
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  const withoutTrailing = withLeading.replace(/\/+$/, '')
+  return withoutTrailing || '/'
+}
+
+function normalizeRewriteBase(pathname: string): string {
+  if (!pathname) {
+    return '/'
+  }
+
+  const withoutTrailing = pathname.replace(/\/+$/, '')
+  return withoutTrailing || '/'
+}
+
+function createProxyConfig(env: Record<string, string>): Record<string, ProxyOptions> {
+  const proxyBase = normalizeProxyBase(env.VITE_API_DEV_PROXY_BASE)
+  const rawApiBase = env.VITE_API_BASE?.trim()
+  const proxies: Record<string, ProxyOptions> = {}
+
+  if (rawApiBase && ABSOLUTE_URL_PATTERN.test(rawApiBase)) {
+    try {
+      const apiURL = new URL(rawApiBase)
+      const target = `${apiURL.protocol}//${apiURL.host}`
+      const rewriteBase = normalizeRewriteBase(apiURL.pathname)
+      const pattern = new RegExp(`^${escapeForRegex(proxyBase)}`)
+
+      proxies[proxyBase] = {
+        target,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(pattern, rewriteBase),
+      }
+    } catch {
+      // Ignore parse failures and fall back to the default proxy below
+    }
+  }
+
+  if (!proxies[proxyBase]) {
+    const pattern = new RegExp(`^${escapeForRegex(proxyBase)}`)
+    proxies[proxyBase] = {
       target: 'http://45.8.116.32',
       changeOrigin: true,
-      rewrite: (path) => path.replace(/^\/api/, '/dtj/nsi/api'),
-    },
-  },
-},
+      rewrite: (path) => path.replace(pattern, '/dtj/nsi/api'),
+    }
+  }
 
+  return proxies
+}
+
+// https://vite.dev/config/
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    plugins: [vue(), vueDevTools()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
+    server: {
+      proxy: createProxyConfig(env),
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- return a normalized relative login path when no absolute auth login URL is provided so Axios keeps the API base URL prefix
- remove the unused helper that manually joined the login path with the base URL
- automatically fall back to a same-origin proxy during development when VITE_API_BASE resolves to another origin, with an override via VITE_API_DEV_PROXY_BASE
- derive the Vite dev server proxy target and rewrite from the configured API base, falling back to the existing backend prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbfbebc19483218c96c34fdd8ff21c