### PR TITLE
Simplify axios client configuration

### DIFF
--- a/src/shared/api/httpClient.ts
+++ b/src/shared/api/httpClient.ts
@@ -5,68 +5,8 @@
 import axios from 'axios'
 import type { AxiosInstance, AxiosRequestConfig } from 'axios'
 
-const ABSOLUTE_URL_PATTERN = /^([a-z][a-z\d+\-.]*:)?\/\//i
-
-function stripTrailingSlashes(value: string): string {
-  return value.replace(/\/+$/, '')
-}
-
-function ensureLeadingSlash(value: string): string {
-  if (!value.startsWith('/')) {
-    return `/${value}`
-  }
-  return value
-}
-
-function normalizeRelativeBase(value: string | undefined | null): string {
-  const trimmed = value?.trim()
-  if (!trimmed) {
-    return '/api'
-  }
-
-  const withoutTrailing = stripTrailingSlashes(trimmed)
-  if (!withoutTrailing) {
-    return '/'
-  }
-
-  return ensureLeadingSlash(withoutTrailing)
-}
-
-function resolveBaseURL(): string {
-  const rawBase = import.meta.env.VITE_API_BASE
-  const devProxyBase = normalizeRelativeBase(import.meta.env.VITE_API_DEV_PROXY_BASE)
-
-  if (!rawBase) {
-    return devProxyBase
-  }
-
-  const trimmedBase = rawBase.trim()
-  if (!trimmedBase) {
-    return devProxyBase
-  }
-
-  if (ABSOLUTE_URL_PATTERN.test(trimmedBase)) {
-    if (import.meta.env.DEV && typeof window !== 'undefined') {
-      try {
-        const target = new URL(trimmedBase)
-        if (target.origin !== window.location.origin) {
-          return devProxyBase
-        }
-      } catch {
-        return devProxyBase
-      }
-    }
-
-    return stripTrailingSlashes(trimmedBase)
-  }
-
-  return normalizeRelativeBase(trimmedBase)
-}
-
-const baseURL = resolveBaseURL()
-
 export const api: AxiosInstance = axios.create({
-  baseURL,
+  baseURL: '/',
   withCredentials: true,
 })
 
@@ -92,14 +32,15 @@ export async function del<T>(url: string, config?: AxiosRequestConfig) {
 
 export async function postForm<T>(
   url: string,
-  body: URLSearchParams,
+  body: URLSearchParams | FormData,
   config?: AxiosRequestConfig,
 ) {
   const requestConfig: AxiosRequestConfig = {
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    responseType: 'text',
-    transformResponse: (value) => value,
     ...config,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...(config?.headers ?? {}),
+    },
   }
   const { data } = await api.post<T>(url, body, requestConfig)
   return data


### PR DESCRIPTION
## Summary
- replace the dynamic base URL calculation with a static axios instance configured for the root path
- simplify the HTTP helper wrappers to use the shared instance without additional logic
- allow `postForm` to accept URLSearchParams or FormData while always sending urlencoded headers

## Testing
- npm run lint *(fails: existing lint errors in api/[[...path]].ts and api/proxy.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68da6a6e8d548321803fcfd9bb2a196a