### PR TITLE
Remove legacy utils HTTP helper

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,9 +1,0 @@
-// src/utils/http.ts
-import axios from 'axios'
-
-const http = axios.create({
-  baseURL: '/', // важное: не внешний домен!
-  withCredentials: true, // чтобы сессия/куки работали через наш прокси
-})
-
-export default http


### PR DESCRIPTION
## Summary
- remove the outdated `src/utils/http.ts` axios helper in favor of the shared HTTP client

## Testing
- not run (pre-commit lint fails because of existing lint errors in `api/` files)


------
https://chatgpt.com/codex/tasks/task_e_68da6c4ed8cc83218b8e0b94ed00ed0d