### PR TITLE
feat: add object defect mutation hooks

### DIFF
--- a/src/features/object-defect-crud/index.ts
+++ b/src/features/object-defect-crud/index.ts
@@ -1,1 +1,2 @@
 export * from './model/useObjectDefectsQuery'
+export * from './model/useObjectDefectMutations'

--- a/src/features/object-defect-crud/model/useObjectDefectMutations.ts
+++ b/src/features/object-defect-crud/model/useObjectDefectMutations.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import {
+  createDefect,
+  deleteDefect,
+  updateDefect,
+  type CreateObjectDefectPayload,
+  type UpdateObjectDefectPayload,
+} from '@entities/object-defect'
+
+export interface RemoveObjectDefectPayload {
+  id: string | number
+}
+
+export function useObjectDefectMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['object-defects'] })
+
+  const create = useMutation({
+    mutationFn: (payload: CreateObjectDefectPayload) => createDefect(payload),
+    onSuccess: () => invalidate(),
+  })
+
+  const update = useMutation({
+    mutationFn: (payload: UpdateObjectDefectPayload) => updateDefect(payload),
+    onSuccess: () => invalidate(),
+  })
+
+  const remove = useMutation({
+    mutationFn: ({ id }: RemoveObjectDefectPayload) => deleteDefect(id),
+    onSuccess: () => invalidate(),
+  })
+
+  return { create, update, remove }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `useObjectDefectMutations` hook that wraps create, update, and delete RPC calls
- invalidate the object defect list after successful mutations and export the hook via the feature barrel

## Testing
- `npm run typecheck`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68dce68084f08321bf04d615fbc762f4