### PR TITLE
docs: add header comments to object defect crud modules

### DIFF
--- a/src/features/object-defect-crud/index.ts
+++ b/src/features/object-defect-crud/index.ts
@@ -1,3 +1,7 @@
+/** Файл: src/features/object-defect-crud/index.ts
+ *  Назначение: Собирает и переэкспортирует публичные хуки и утилиты CRUD дефектов объектов.
+ *  Использование: Импортируйте из фичи при работе с дефектами объектов и их синхронизацией.
+ */
 /** Публичный API фичи CRUD дефектов объектов */
 export { useObjectDefectsQuery } from './model/useObjectDefectsQuery'
 export {

--- a/src/features/object-defect-crud/model/componentSync.ts
+++ b/src/features/object-defect-crud/model/componentSync.ts
@@ -1,3 +1,7 @@
+/** Файл: src/features/object-defect-crud/model/componentSync.ts
+ *  Назначение: Содержит утилиты для построения справочников компонентов и категорий дефектов и расчёта удалённых связей.
+ *  Использование: Используйте функции при синхронизации данных дефектов с выбором пользователя.
+ */
 import { normalizeText } from '@shared/lib'
 import type {
   DefectCategoryOption,

--- a/src/features/object-defect-crud/model/useObjectDefectMutations.ts
+++ b/src/features/object-defect-crud/model/useObjectDefectMutations.ts
@@ -1,3 +1,7 @@
+/** Файл: src/features/object-defect-crud/model/useObjectDefectMutations.ts
+ *  Назначение: Настраивает vue-query мутации для создания, обновления и удаления дефектов объекта.
+ *  Использование: Подключайте хук в компонентах для управления дефектами и инвалидации кэша.
+ */
 import { useMutation, useQueryClient } from '@tanstack/vue-query'
 import {
   createDefect,

--- a/src/features/object-defect-crud/model/useObjectDefectsQuery.ts
+++ b/src/features/object-defect-crud/model/useObjectDefectsQuery.ts
@@ -1,3 +1,7 @@
+/** Файл: src/features/object-defect-crud/model/useObjectDefectsQuery.ts
+ *  Назначение: Определяет vue-query запрос для получения снимка дефектов объекта.
+ *  Использование: Вызывайте хук в компонентах для загрузки актуального списка дефектов.
+ */
 import { useQuery } from '@tanstack/vue-query'
 import { fetchObjectDefectsSnapshot } from '@entities/object-defect'
 


### PR DESCRIPTION
## Summary
- add descriptive header comments to the object defect CRUD public API and supporting hooks

## Testing
- vue-tsc --noEmit -p tsconfig.json
- eslint . --ext .ts,.vue

------
https://chatgpt.com/codex/tasks/task_e_68dcec868e988321a91cc2571d066f69