### PR TITLE
Fix component filter to use component names

### DIFF
--- a/src/pages/nsi/ObjectDefectsPage.vue
+++ b/src/pages/nsi/ObjectDefectsPage.vue
@@ -395,8 +395,11 @@ const filteredRows = computed(() => {
     }
 
     if (selectedComponent) {
-      const note = normalizeText(item.note ?? '')
-      if (!note || note !== selectedComponent) {
+      const componentName = normalizeText(item.componentName ?? '')
+      const componentId = componentName ? '' : normalizeText(item.componentId ?? '')
+      const componentKey = componentName || componentId
+
+      if (!componentKey || componentKey !== selectedComponent) {
         return false
       }
     }


### PR DESCRIPTION
## Summary
- ensure component filter compares against the normalized component name with an ID fallback

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de0b260f50832180a295cf27175e05