### PR TITLE
Fix defect payload name property

### DIFF
--- a/src/entities/object-defect/api/repository.test.ts
+++ b/src/entities/object-defect/api/repository.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SaveDefectRecord } from '../model/dto'
+import type { CreateObjectDefectPayload } from '../model/types'
+
+vi.mock('@shared/api', () => ({
+  rpc: vi.fn(),
+}))
+
+import { rpc } from '@shared/api'
+import { createDefect, updateDefect } from './repository'
+
+const rpcMock = vi.mocked(rpc)
+
+const baseResponse: SaveDefectRecord[] = [
+  {
+    id: 'defect-id',
+    name: 'defect-id',
+  },
+]
+
+const basePayload: CreateObjectDefectPayload = {
+  name: '  New defect  ',
+  componentId: 'component-id',
+  componentPvId: 'component-pv-id',
+  categoryFvId: 'category-fv-id',
+  categoryPvId: 'category-pv-id',
+  index: '1',
+  note: 'note',
+}
+
+describe('object defect repository mutations', () => {
+  beforeEach(() => {
+    rpcMock.mockReset()
+  })
+
+  it('sends trimmed name for createDefect', async () => {
+    rpcMock.mockResolvedValueOnce(baseResponse)
+
+    await createDefect(basePayload)
+
+    expect(rpcMock).toHaveBeenCalledTimes(1)
+    const [, params] = rpcMock.mock.calls[0] as [string, unknown[]]
+    expect(Array.isArray(params)).toBe(true)
+    const payload = (params as unknown[])[1] as Record<string, unknown>
+    expect(payload).toHaveProperty('name', 'New defect')
+  })
+
+  it('sends trimmed name for updateDefect', async () => {
+    rpcMock.mockResolvedValueOnce(baseResponse)
+
+    await updateDefect({ ...basePayload, id: 'defect-id' })
+
+    expect(rpcMock).toHaveBeenCalledTimes(1)
+    const [, params] = rpcMock.mock.calls[0] as [string, unknown[]]
+    expect(Array.isArray(params)).toBe(true)
+    const payload = (params as unknown[])[1] as Record<string, unknown>
+    expect(payload).toMatchObject({ name: 'New defect', id: 'defect-id' })
+  })
+})

--- a/src/entities/object-defect/api/repository.ts
+++ b/src/entities/object-defect/api/repository.ts
@@ -252,7 +252,7 @@ function mapDefect(
 function buildDefectPayload(payload: CreateObjectDefectPayload) {
   return {
     accessLevel: 1,
-    DefectsName: trimmedString(payload.name) || null,
+    name: trimmedString(payload.name) || null,
     objDefectsComponent: payload.componentId ?? 0,
     pvDefectsComponent: payload.componentPvId ?? 0,
     fvDefectsCategory: payload.categoryFvId ?? 0,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,13 @@ import { fileURLToPath } from 'node:url'
 import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
 import viteConfig from './vite.config'
 
+const resolvedViteConfig =
+  typeof viteConfig === 'function'
+    ? viteConfig({ command: 'serve', mode: 'test' })
+    : viteConfig
+
 export default mergeConfig(
-  viteConfig,
+  resolvedViteConfig,
   defineConfig({
     test: {
       environment: 'jsdom',


### PR DESCRIPTION
## Summary
- update the defect save payload to send the trimmed `name` field
- fix Vitest configuration so the Vite factory config resolves during tests
- add repository tests that ensure create/update RPC calls include the trimmed name

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68de0d35fd2c83218c872698e2687d52