### PR TITLE
Handle defect recreation when editing

### DIFF
--- a/src/entities/object-defect/api/__tests__/repository.spec.ts
+++ b/src/entities/object-defect/api/__tests__/repository.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@shared/api', () => ({
+  rpc: vi.fn(),
+}))
+
+import { rpc } from '@shared/api'
+import { deleteDefectOwnerWithProperties } from '../repository'
+
+const rpcMock = vi.mocked(rpc)
+
+describe('deleteDefectOwnerWithProperties', () => {
+  beforeEach(() => {
+    rpcMock.mockReset()
+  })
+
+  it('returns success when rpc resolves without message', async () => {
+    rpcMock.mockResolvedValueOnce(null)
+
+    const result = await deleteDefectOwnerWithProperties(10)
+
+    expect(result).toEqual({ success: true })
+    expect(rpcMock).toHaveBeenCalledWith('data/deleteOwnerWithProperties', [10, 1])
+  })
+
+  it('returns failure when rpc resolves with a message', async () => {
+    rpcMock.mockResolvedValueOnce('Дефект используется')
+
+    const result = await deleteDefectOwnerWithProperties(5)
+
+    expect(result).toEqual({ success: false, reason: 'Дефект используется' })
+  })
+
+  it('returns failure when rpc throws', async () => {
+    rpcMock.mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await deleteDefectOwnerWithProperties(7)
+
+    expect(result).toEqual({ success: false, reason: 'Network error' })
+  })
+})

--- a/src/entities/object-defect/api/repository.ts
+++ b/src/entities/object-defect/api/repository.ts
@@ -35,6 +35,7 @@ const LOAD_COMPONENT_DEFECT_METHOD = 'data/loadComponentDefect'
 const LOAD_CATEGORIES_METHOD = 'data/loadFvForSelect'
 const SAVE_DEFECTS_METHOD = 'data/saveDefects'
 const DELETE_DEFECTS_METHOD = 'data/deleteDefects'
+const DELETE_OWNER_WITH_PROPERTIES_METHOD = 'data/deleteOwnerWithProperties'
 
 const COMPONENT_DEFECT_ARGS = ['Typ_Components', 'Prop_DefectsComponent'] as const
 const FACTOR_DEFECTS = ['Factor_Defects'] as const
@@ -357,4 +358,28 @@ export async function updateDefect(
 
 export async function deleteDefect(id: string | number): Promise<void> {
   await rpc(DELETE_DEFECTS_METHOD, [id])
+}
+
+export type DeleteDefectOwnerResult =
+  | { success: true; reason?: undefined }
+  | { success: false; reason: string }
+
+export async function deleteDefectOwnerWithProperties(
+  defectId: string | number,
+): Promise<DeleteDefectOwnerResult> {
+  try {
+    const response = await rpc<unknown>(DELETE_OWNER_WITH_PROPERTIES_METHOD, [defectId, 1])
+
+    if (typeof response === 'string') {
+      const trimmed = response.trim()
+      if (trimmed.length > 0) {
+        return { success: false, reason: trimmed }
+      }
+    }
+
+    return { success: true }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { success: false, reason: message }
+  }
 }

--- a/src/pages/nsi/__tests__/ObjectDefectsPage.spec.ts
+++ b/src/pages/nsi/__tests__/ObjectDefectsPage.spec.ts
@@ -1,0 +1,232 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h, defineComponent } from 'vue'
+
+interface TestDefectRow {
+  id: number
+  name: string
+  componentId: string | null
+  componentName: string | null
+  componentPvId: string | null
+  categoryFvId: string | null
+  categoryName: string | null
+  categoryPvId: string | null
+  index: string
+  note: string
+}
+
+interface ExposedFormState {
+  name: string
+  componentId: string | null
+  componentPvId: string | null
+  categoryFvId: string | null
+  categoryPvId: string | null
+  index: string
+  note: string
+}
+
+const messageMock = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+}))
+
+const dialogWarningMock = vi.hoisted(() => vi.fn())
+const createMutateAsync = vi.hoisted(() => vi.fn())
+const updateMutateAsync = vi.hoisted(() => vi.fn())
+const removeMutateAsync = vi.hoisted(() => vi.fn())
+const deleteDefectOwnerWithPropertiesMock = vi.hoisted(() => vi.fn())
+
+const snapshotRef = vi.hoisted(() => ({
+  value: {
+    items: [] as TestDefectRow[],
+    categories: [],
+    components: [],
+  },
+}))
+
+function createComponentStub(name: string) {
+  return defineComponent({
+    name,
+    props: ['value', 'modelValue', 'show'],
+    setup(_, { slots }) {
+      return () => h('div', { class: name }, slots.default ? slots.default() : null)
+    },
+  })
+}
+
+vi.mock('naive-ui', () => ({
+  NButton: createComponentStub('NButton'),
+  NCard: createComponentStub('NCard'),
+  NDataTable: createComponentStub('NDataTable'),
+  NForm: createComponentStub('NForm'),
+  NFormItem: createComponentStub('NFormItem'),
+  NIcon: createComponentStub('NIcon'),
+  NInput: createComponentStub('NInput'),
+  NModal: createComponentStub('NModal'),
+  NPagination: createComponentStub('NPagination'),
+  NPopconfirm: createComponentStub('NPopconfirm'),
+  NSelect: createComponentStub('NSelect'),
+  NTag: createComponentStub('NTag'),
+  useMessage: () => messageMock,
+  useDialog: () => ({ warning: dialogWarningMock }),
+}))
+
+vi.mock('@features/object-defect-crud', () => ({
+  useObjectDefectsQuery: () => ({
+    data: snapshotRef,
+    isLoading: { value: false },
+    isFetching: { value: false },
+    error: { value: null },
+  }),
+  useObjectDefectMutations: () => ({
+    create: { mutateAsync: createMutateAsync },
+    update: { mutateAsync: updateMutateAsync },
+    remove: { mutateAsync: removeMutateAsync },
+  }),
+  createDefectComponentLookup: () => ({
+    byId: new Map(),
+    byPvId: new Map(),
+    usageById: new Map(),
+    usageByPvId: new Map(),
+    usageByName: new Map(),
+  }),
+  createDefectCategoryLookup: () => ({
+    byFvId: new Map(),
+    byPvId: new Map(),
+    usageByFvId: new Map(),
+    usageByPvId: new Map(),
+    usageByName: new Map(),
+  }),
+}))
+
+vi.mock('@entities/object-defect', () => ({
+  deleteDefectOwnerWithProperties: deleteDefectOwnerWithPropertiesMock,
+}))
+
+import ObjectDefectsPage from '../ObjectDefectsPage.vue'
+
+describe('ObjectDefectsPage save flow', () => {
+  beforeAll(() => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  })
+
+  beforeEach(() => {
+    snapshotRef.value = {
+      items: [
+        {
+          id: 1,
+          name: 'Existing defect',
+          componentId: null,
+          componentName: null,
+          componentPvId: null,
+          categoryFvId: null,
+          categoryName: null,
+          categoryPvId: null,
+          index: '',
+          note: '',
+        },
+      ],
+      categories: [],
+      components: [],
+    }
+
+    messageMock.success.mockReset()
+    messageMock.error.mockReset()
+    messageMock.info.mockReset()
+    messageMock.warning.mockReset()
+
+    dialogWarningMock.mockReset()
+    dialogWarningMock.mockImplementation(() => {})
+
+    createMutateAsync.mockReset()
+    updateMutateAsync.mockReset()
+    removeMutateAsync.mockReset()
+    deleteDefectOwnerWithPropertiesMock.mockReset()
+  })
+
+  it('calls deleteDefectOwnerWithProperties when saving edited defect', async () => {
+    deleteDefectOwnerWithPropertiesMock.mockResolvedValue({ success: true })
+    createMutateAsync.mockResolvedValue(undefined)
+
+    const wrapper = mount(ObjectDefectsPage)
+    const vm = wrapper.vm as unknown as {
+      openEdit: (row: TestDefectRow) => void
+      form: ExposedFormState
+      save: () => Promise<void>
+    }
+
+    vm.openEdit(snapshotRef.value.items[0])
+    vm.form.name = 'Updated defect'
+
+    await vm.save()
+
+    expect(deleteDefectOwnerWithPropertiesMock).toHaveBeenCalledWith(1)
+  })
+
+  it('stops saving and keeps edit mode when deletion fails', async () => {
+    deleteDefectOwnerWithPropertiesMock.mockResolvedValue({
+      success: false,
+      reason: 'Дефект используется в нормативных связях',
+    })
+    dialogWarningMock.mockImplementation((options: { onNegativeClick?: () => void }) => {
+      options.onNegativeClick?.()
+    })
+
+    const wrapper = mount(ObjectDefectsPage)
+    const vm = wrapper.vm as unknown as {
+      openEdit: (row: TestDefectRow) => void
+      form: ExposedFormState
+      save: () => Promise<void>
+    }
+
+    vm.openEdit(snapshotRef.value.items[0])
+    vm.form.name = 'Updated defect'
+
+    await vm.save()
+
+    expect(createMutateAsync).not.toHaveBeenCalled()
+    expect(messageMock.error).toHaveBeenCalledWith(
+      'Дефект используется в нормативных связях',
+    )
+    expect(dialogWarningMock).toHaveBeenCalled()
+  })
+
+  it('creates new defect after successful deletion', async () => {
+    deleteDefectOwnerWithPropertiesMock.mockResolvedValue({ success: true })
+    createMutateAsync.mockResolvedValue(undefined)
+
+    const wrapper = mount(ObjectDefectsPage)
+    const vm = wrapper.vm as unknown as {
+      openEdit: (row: TestDefectRow) => void
+      form: ExposedFormState
+      save: () => Promise<void>
+    }
+
+    vm.openEdit(snapshotRef.value.items[0])
+    vm.form.name = 'Updated defect'
+    vm.form.note = 'Comment'
+
+    await vm.save()
+
+    expect(createMutateAsync).toHaveBeenCalledTimes(1)
+    expect(createMutateAsync).toHaveBeenCalledWith({
+      name: 'Updated defect',
+      componentId: null,
+      componentPvId: null,
+      categoryFvId: null,
+      categoryPvId: null,
+      index: null,
+      note: 'Comment',
+    })
+    expect(messageMock.success).toHaveBeenCalledWith('Дефект обновлён')
+    expect(updateMutateAsync).not.toHaveBeenCalled()
+    expect(dialogWarningMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add a repository helper that calls `data/deleteOwnerWithProperties` and reports usage conflicts
- update the ObjectDefectsPage save flow to validate deletion, offer creation when blocked, and recreate defects after removal
- cover the new behaviour with repository and page unit tests

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68de1949f6288321ba580580f0f3da83