### PR TITLE
feat: add object parameter CRUD feature hooks

### DIFF
--- a/src/features/object-parameter-crud/index.ts
+++ b/src/features/object-parameter-crud/index.ts
@@ -1,0 +1,7 @@
+/** Файл: src/features/object-parameter-crud/index.ts
+ *  Назначение: публичный API фичи управления параметрами обслуживаемых объектов.
+ *  Использование: импортируйте хуки и утилиты фичи через этот баррель.
+ */
+export * from './model/useObjectParametersQuery'
+export * from './model/useObjectParameterMutations'
+export * from './model/directories'

--- a/src/features/object-parameter-crud/model/directories.ts
+++ b/src/features/object-parameter-crud/model/directories.ts
@@ -1,0 +1,43 @@
+/** Файл: src/features/object-parameter-crud/model/directories.ts
+ *  Назначение: вспомогательные утилиты для работы с директориями параметров обслуживаемых объектов.
+ *  Использование: импортируйте генераторы lookup и сортировок в хуках и компонентах фичи.
+ */
+import type { LoadedObjectParameter } from '@entities/object-parameter'
+
+export type DirectoryOption = { id: string; name: string }
+
+export type DirectoryLookup<Option extends DirectoryOption = DirectoryOption> = Record<string, Option>
+
+export function createDirectoryLookup<Option extends DirectoryOption>(
+  options: Option[],
+): DirectoryLookup<Option> {
+  return options.reduce<DirectoryLookup<Option>>((acc, option) => {
+    acc[String(option.id)] = option
+    return acc
+  }, {})
+}
+
+export function sortByNameRu<Option extends { name: string }>(options: Option[]): Option[] {
+  return [...options].sort((a, b) => a.name.localeCompare(b.name, 'ru'))
+}
+
+export function sortParameters(
+  items: LoadedObjectParameter[],
+  options?: { groupFirst?: boolean },
+): LoadedObjectParameter[] {
+  const groupFirst = options?.groupFirst ?? true
+  const sorted = [...items]
+
+  sorted.sort((a, b) => {
+    if (groupFirst) {
+      const groupA = a.groupName ?? ''
+      const groupB = b.groupName ?? ''
+      const groupCompare = groupA.localeCompare(groupB, 'ru')
+      if (groupCompare !== 0) return groupCompare
+    }
+
+    return a.name.localeCompare(b.name, 'ru')
+  })
+
+  return sorted
+}

--- a/src/features/object-parameter-crud/model/useObjectParameterMutations.ts
+++ b/src/features/object-parameter-crud/model/useObjectParameterMutations.ts
@@ -1,0 +1,40 @@
+/** Файл: src/features/object-parameter-crud/model/useObjectParameterMutations.ts
+ *  Назначение: vue-query мутации создания, обновления и удаления параметров обслуживаемых объектов.
+ *  Использование: подключайте хук в формах для выполнения операций и инвалидации кэша справочника.
+ */
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import {
+  createParameter,
+  deleteParameter,
+  updateParameter,
+  type ObjectParameter,
+} from '@entities/object-parameter'
+
+export type CreateObjectParameterPayload = Omit<ObjectParameter, 'id'> & { id?: string }
+export type UpdateObjectParameterPayload = ObjectParameter
+
+export interface RemoveObjectParameterPayload {
+  id: string
+}
+
+export function useObjectParameterMutations() {
+  const qc = useQueryClient()
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['object-parameters'] })
+
+  const create = useMutation({
+    mutationFn: (payload: CreateObjectParameterPayload) => createParameter(payload),
+    onSuccess: () => invalidate(),
+  })
+
+  const update = useMutation({
+    mutationFn: (payload: UpdateObjectParameterPayload) => updateParameter(payload),
+    onSuccess: () => invalidate(),
+  })
+
+  const remove = useMutation({
+    mutationFn: ({ id }: RemoveObjectParameterPayload) => deleteParameter(id),
+    onSuccess: () => invalidate(),
+  })
+
+  return { create, update, remove }
+}

--- a/src/features/object-parameter-crud/model/useObjectParametersQuery.ts
+++ b/src/features/object-parameter-crud/model/useObjectParametersQuery.ts
@@ -1,0 +1,41 @@
+/** Файл: src/features/object-parameter-crud/model/useObjectParametersQuery.ts
+ *  Назначение: vue-query запрос для загрузки и подготовки справочника параметров обслуживаемых объектов.
+ *  Использование: подключайте хук на страницах/в виджетах, чтобы получать снапшот и лукапы директорий.
+ */
+import { useQuery } from '@tanstack/vue-query'
+import { fetchObjectParametersSnapshot } from '@entities/object-parameter'
+import type { ObjectParametersSnapshot } from '@entities/object-parameter'
+import {
+  createDirectoryLookup,
+  sortByNameRu,
+  sortParameters,
+  type DirectoryLookup,
+} from './directories'
+
+type UnitOption = ObjectParametersSnapshot['unitOptions'][number]
+type GroupOption = ObjectParametersSnapshot['groupOptions'][number]
+
+export interface ObjectParametersQueryData extends ObjectParametersSnapshot {
+  unitLookup: DirectoryLookup<UnitOption>
+  groupLookup: DirectoryLookup<GroupOption>
+}
+
+export function useObjectParametersQuery() {
+  return useQuery({
+    queryKey: ['object-parameters'],
+    queryFn: fetchObjectParametersSnapshot,
+    select: (snapshot): ObjectParametersQueryData => {
+      const sortedUnits = sortByNameRu(snapshot.unitOptions)
+      const sortedGroups = sortByNameRu(snapshot.groupOptions)
+
+      return {
+        ...snapshot,
+        items: sortParameters(snapshot.items),
+        unitOptions: sortedUnits,
+        groupOptions: sortedGroups,
+        unitLookup: createDirectoryLookup(sortedUnits),
+        groupLookup: createDirectoryLookup(sortedGroups),
+      }
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add vue-query query hook that prepares lookups and sorting for object parameter directories
- provide CRUD mutation hook with cache invalidation and reusable directory utilities
- expose the new feature API through a barrel export

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfdde9e764832191081b25525e2d37