### PR TITLE
Ensure card action buttons remain visible on mobile

### DIFF
--- a/src/pages/nsi/ObjectParametersPage.vue
+++ b/src/pages/nsi/ObjectParametersPage.vue
@@ -761,6 +761,8 @@ const deleteParameter = (row: LoadedObjectParameter) => {
 
 .card__actions .table-actions {
   justify-content: flex-start;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- force mobile card action containers to stay visible by overriding opacity and pointer events

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e21eb902588321924dd36b4da2efca